### PR TITLE
feat(markview): use nixvim option instead of raw lua

### DIFF
--- a/config/plug/utils/markview.nix
+++ b/config/plug/utils/markview.nix
@@ -1,21 +1,19 @@
 {
   plugins.markview = {
     enable = true;
-  };
-
-  extraConfigLua = ''
-    require('markview').setup({
-
-      modes = {"n", "no", "c"},
-
-      hybrid_modes = { "n"},
-
-      callbacks = {
-        on_enable = function (_, win)
+    settings = {
+      modes = [
+        "n"
+        "no"
+        "c"
+      ];
+      hybrid_modes = [ "n" ];
+      callback.on_enable.__raw = ''
+        function (_, win)
           vim.wo[win].conceallevel = 2;
           vim.wo[win].concealcursor = "c";
         end
-      }  
-    })
-  '';
+      '';
+    };
+  };
 }


### PR DESCRIPTION
Hello ! I just stumbled upon your repo and wanted to give you an example on how to do things the Nixvim's way.

When you configure a plugin using Nixvim, you can usually find all the configuration option you would normally write in Lua in Nix.
You can refer to Nixvim's official documentation to see all the available options
https://nix-community.github.io/nixvim/plugins/markview/settings/index.html

For example, this PR implements the markview configuration you did un Lua using the Nixvim's options